### PR TITLE
Change default ProtVer from 1337 to 14

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -127,7 +127,7 @@ pub const ARTNET_HEADER: &[u8] = b"Art-Net\0";
 /// The protocol version. Anything above [4, 0] seems to work for the devices that this library was tested on.
 ///
 /// If you need a different or configurable protocol version, please open a PR.
-pub const ARTNET_PROTOCOL_VERSION: [u8; 2] = [5, 57];
+pub const ARTNET_PROTOCOL_VERSION: [u8; 2] = [0, 14];
 
 impl ArtCommand {
     /// Convert an ArtCommand in a byte buffer, which can be send to an UDP socket.


### PR DESCRIPTION
See [Art-Net 4 Protocol Release V1.4 Document Revision 1.4dd 22/1/2017](https://artisticlicence.com/WebSiteMaster/User%20Guides/art-net.pdf) page 47.
Also see the [Art-Net Homepage](https://art-net.org.uk/structure/streaming-packets/artdmx-packet-definition/) under ProtVer.

Increasing ProtVer above 14 works today. But in the future a device may
actually support a higher version of Art-Net and then we may be
breaking compatibility because we don't support this higher version but
claim that we do.
It's a funny easter egg, but breaking forward compatibility should
be avoided.