### PR TITLE
Fixed an issue with the length and data of an output field

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'artnet_protocol'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=artnet_protocol"
+                ],
+                "filter": {
+                    "name": "artnet_protocol",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -150,7 +150,10 @@ impl ArtCommand {
     /// Convert an a byte buffer to a command.
     pub fn from_buffer(buffer: &[u8]) -> Result<ArtCommand> {
         if buffer.len() < 13 {
-            return Err(Error::MessageTooShort(buffer.to_vec()));
+            return Err(Error::MessageSizeInvalid {
+                message: buffer.to_vec(),
+                allowed_size: 13..1024, // I'm not sure what the actually allowed size is of an artnet packet, if this is wrong feel free to correct it
+            });
         }
         if &buffer[..8] != ARTNET_HEADER {
             return Err(Error::InvalidArtnetHeader(buffer.to_vec()));

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -122,7 +122,7 @@ pub enum ArtCommand {
 }
 
 /// The ArtNet header. This is the first 8 bytes of each message, and contains the text "Art-Net\0"
-pub const ARTNET_HEADER: &[u8] = b"Art-Net\0";
+pub const ARTNET_HEADER: &[u8; 8] = b"Art-Net\0";
 
 /// The protocol version. Anything above [4, 0] seems to work for the devices that this library was tested on.
 ///
@@ -149,13 +149,16 @@ impl ArtCommand {
 
     /// Convert an a byte buffer to a command.
     pub fn from_buffer(buffer: &[u8]) -> Result<ArtCommand> {
-        if buffer.len() < 13 {
-            return Err(Error::MessageSizeInvalid {
+        const MIN_BUFFER_LENGTH: usize = 14;
+
+        if buffer.len() < MIN_BUFFER_LENGTH {
+            return Err(Error::MessageTooShort {
                 message: buffer.to_vec(),
-                allowed_size: 13..1024, // I'm not sure what the actually allowed size is of an artnet packet, if this is wrong feel free to correct it
+                min_len: MIN_BUFFER_LENGTH,
             });
         }
-        if &buffer[..8] != ARTNET_HEADER {
+
+        if !buffer.starts_with(ARTNET_HEADER) {
             return Err(Error::InvalidArtnetHeader(buffer.to_vec()));
         }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -251,100 +251,6 @@ mod tests {
 
     mod parsing {
         use super::*;
-        #[test]
-        fn length_0_should_fail() {
-            // Here length is 0
-            // should fail because it is lower than 2
-            assert!(ArtCommand::from_buffer(&vec![
-                65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 0, 0,
-            ])
-            .is_err());
-        }
-
-        #[test]
-        fn length_1_should_fail() {
-            // Here length is 1
-            // should fail because it is uneven and lower than 2
-            assert!(ArtCommand::from_buffer(&vec![
-                65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 0, 1, 255,
-            ])
-            .is_err());
-        }
-
-        #[test]
-        fn length_3_should_fail() {
-            // Here length is 3
-            // should fail because it is uneven
-            assert!(ArtCommand::from_buffer(&vec![
-                65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 0, 3, 255, 255, 255
-            ])
-            .is_err());
-        }
-
-        #[test]
-        fn length_513_should_fail() {
-            // Here length is 513
-            // should fail because it is uneven and above 512
-            // Here length is 513 (over 512 and uneven should fail)
-            assert!(ArtCommand::from_buffer(
-                &vec![
-                    vec![65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 2, 1,],
-                    vec![255; 513],
-                ]
-                .concat()
-            )
-            .is_err());
-        }
-
-        #[test]
-        fn length_514_should_fail() {
-            // Here length is 514
-            // should fail because it is above 512
-            assert!(ArtCommand::from_buffer(
-                &vec![
-                    vec![65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 2, 2,],
-                    vec![255; 514],
-                ]
-                .concat()
-            )
-            .is_err());
-        }
-
-        #[test]
-        fn data_shorter_than_length_should_fail() {
-            // Here length field claims 512 bytes of data, but only 510 bytes are delivered
-            assert!(ArtCommand::from_buffer(
-                &vec![
-                    vec![65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 2, 0,],
-                    vec![255; 510],
-                ]
-                .concat()
-            )
-            .is_err());
-        }
-
-        #[test]
-        fn data_longer_than_length() {
-            // Parser must only parse as many bytes as length tells it to
-            // After that it must ignore all data bytes
-            let packet = &vec![
-                vec![
-                    65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 0, 2,
-                ],
-                vec![255; 512],
-            ]
-            .concat();
-            // jump through hoops to compare the results to what we expect...
-            let command = ArtCommand::from_buffer(packet).unwrap();
-            if let ArtCommand::Output(output) = command {
-                assert_eq!(output.version, [0, 14]);
-                assert_eq!(output.sequence, 0);
-                assert_eq!(output.physical, 0);
-                assert_eq!(output.port_address, 1.into());
-                assert_eq!(output.length.parsed_length, Some(2));
-                assert_eq!(output.data.inner, vec![255, 255]);
-            }
-        }
 
         #[test]
         fn protver_below_14() {
@@ -363,16 +269,6 @@ mod tests {
                 assert_eq!(output.length.parsed_length, Some(2));
                 assert_eq!(output.data.inner, vec![255, 255]);
             }
-        }
-
-        #[test]
-        fn protver_above_14_should_fail() {
-            // Here protocol version is 15
-            // Any version above 14 should fail because we may not be able to parse it
-            assert!(ArtCommand::from_buffer(&vec![
-                65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 15, 0, 0, 1, 0, 0, 2, 255, 255,
-            ])
-            .is_err());
         }
 
         #[test]

--- a/src/command/output/mod.rs
+++ b/src/command/output/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use crate::{command::ARTNET_PROTOCOL_VERSION, convert::Convertable, Error, PortAddress, Result};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::Cursor;
@@ -167,123 +170,6 @@ impl Convertable<Output> for BigEndianLength<Output> {
             true
         } else {
             self.parsed_length == other.parsed_length
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ArtCommand;
-
-    mod serialization {
-        use super::*;
-        #[test]
-        fn create_single_dmx_value_art_dmx_packet() {
-            let command = ArtCommand::Output(Output {
-                data: vec![255].into(), // The data we're sending to the node
-                ..Output::default()
-            });
-            let bytes = command.into_buffer().unwrap();
-            let comparison = vec![
-                65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 0, 2, 255, 0,
-            ]; //is padded with zero to even length of two
-            assert_eq!(bytes, comparison)
-        }
-        #[test]
-        fn create_512_dmx_values_art_dmx_packet() {
-            let command = ArtCommand::Output(Output {
-                data: vec![128; 512].into(), // The data we're sending to the node
-                ..Output::default()
-            });
-            let bytes = command.into_buffer().unwrap();
-            let comparison = vec![
-                vec![
-                    65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 2, 0,
-                ],
-                vec![128; 512],
-            ]
-            .concat(); //is padded with zero to even length of two
-            assert_eq!(bytes, comparison)
-        }
-        #[test]
-        fn test_invalid_length() {
-            let command = ArtCommand::Output(Output {
-                data: vec![0xff; 512].into(),
-                ..Output::default()
-            });
-            let buffer = command.into_buffer().unwrap();
-            // #6: length needs to be encoded in big endian
-            assert_eq!(&buffer[0x10..=0x11], &[2, 0]);
-            // #7.1: packets need to be an even number
-            fn get_data(command: &ArtCommand) -> &PaddedData {
-                if let ArtCommand::Output(output) = command {
-                    &output.data
-                } else {
-                    unreachable!()
-                }
-            };
-            let command = ArtCommand::Output(Output {
-                data: vec![0xff].into(),
-                ..Output::default()
-            });
-            // Initially it will be 1
-            assert_eq!(get_data(&command).len(), 1);
-            // But the padded length is 2
-            assert_eq!(get_data(&command).len_rounded_up(), 2);
-            let buffer = command.into_buffer().unwrap();
-            // The data written is 2 bytes
-            assert_eq!(&buffer[0x10..=0x11], &[0, 2]);
-            // #7.2: packets need to be at least 2 bytes
-            let command = ArtCommand::Output(Output {
-                data: vec![].into(),
-                ..Output::default()
-            });
-            assert!(command.into_buffer().is_err());
-            // #7.3: packets need to be at most 512 bytes
-            let command = ArtCommand::Output(Output {
-                data: vec![0xff; 513].into(),
-                ..Output::default()
-            });
-            assert!(command.into_buffer().is_err());
-        }
-    }
-
-    mod parsing {
-        use super::*;
-
-        #[test]
-        fn protver_below_14() {
-            // Because Art-Net is guaranteed to be backwards-compatible,
-            // we should be able to parse versions below 14,
-            // even tough these should never be seen in the wild
-            let packet = &vec![
-                65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 0, 0, 0, 1, 0, 0, 2, 255, 255,
-            ];
-            let command = ArtCommand::from_buffer(packet).unwrap();
-            if let ArtCommand::Output(output) = command {
-                assert_eq!(output.version, [0, 0]);
-                assert_eq!(output.sequence, 0);
-                assert_eq!(output.physical, 0);
-                assert_eq!(output.port_address, 1.into());
-                assert_eq!(output.length.parsed_length, Some(2));
-                assert_eq!(output.data.inner, vec![255, 255]);
-            }
-        }
-
-        #[test]
-        fn invalid_port_address() {
-            // Here Port-Address is 32_768
-            // Any Port-Address over 32_767 should fail
-            assert!(ArtCommand::from_buffer(
-                &vec![
-                    vec![65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0,],
-                    32_768u16.to_le_bytes().to_vec(),
-                    vec![0, 2, 255, 255,],
-                ]
-                .concat()
-            )
-            .is_err());
         }
     }
 }

--- a/src/command/output/tests.rs
+++ b/src/command/output/tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+use crate::ArtCommand;
+
+mod serialization {
+    use super::*;
+    #[test]
+    fn create_single_dmx_value_art_dmx_packet() {
+        let command = ArtCommand::Output(Output {
+            data: vec![255].into(), // The data we're sending to the node
+            ..Output::default()
+        });
+        let bytes = command.into_buffer().unwrap();
+        let comparison = vec![
+            65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 0, 2, 255, 0,
+        ]; //is padded with zero to even length of two
+        assert_eq!(bytes, comparison)
+    }
+    #[test]
+    fn create_512_dmx_values_art_dmx_packet() {
+        let command = ArtCommand::Output(Output {
+            data: vec![128; 512].into(), // The data we're sending to the node
+            ..Output::default()
+        });
+        let bytes = command.into_buffer().unwrap();
+        let comparison = vec![
+            vec![
+                65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, 1, 0, 2, 0,
+            ],
+            vec![128; 512],
+        ]
+        .concat(); //is padded with zero to even length of two
+        assert_eq!(bytes, comparison)
+    }
+    #[test]
+    fn test_invalid_length() {
+        let command = ArtCommand::Output(Output {
+            data: vec![0xff; 512].into(),
+            ..Output::default()
+        });
+        let buffer = command.into_buffer().unwrap();
+        // #6: length needs to be encoded in big endian
+        assert_eq!(&buffer[0x10..=0x11], &[2, 0]);
+        // #7.1: packets need to be an even number
+        fn get_data(command: &ArtCommand) -> &PaddedData {
+            if let ArtCommand::Output(output) = command {
+                &output.data
+            } else {
+                unreachable!()
+            }
+        };
+        let command = ArtCommand::Output(Output {
+            data: vec![0xff].into(),
+            ..Output::default()
+        });
+        // Initially it will be 1
+        assert_eq!(get_data(&command).len(), 1);
+        // But the padded length is 2
+        assert_eq!(get_data(&command).len_rounded_up(), 2);
+        let buffer = command.into_buffer().unwrap();
+        // The data written is 2 bytes
+        assert_eq!(&buffer[0x10..=0x11], &[0, 2]);
+        // #7.2: packets need to be at least 2 bytes
+        let command = ArtCommand::Output(Output {
+            data: vec![].into(),
+            ..Output::default()
+        });
+        assert!(command.into_buffer().is_err());
+        // #7.3: packets need to be at most 512 bytes
+        let command = ArtCommand::Output(Output {
+            data: vec![0xff; 513].into(),
+            ..Output::default()
+        });
+        assert!(command.into_buffer().is_err());
+    }
+}
+
+mod parsing {
+    use super::*;
+
+    #[test]
+    fn protver_below_14() {
+        // Because Art-Net is guaranteed to be backwards-compatible,
+        // we should be able to parse versions below 14,
+        // even tough these should never be seen in the wild
+        let packet = &vec![
+            65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 0, 0, 0, 1, 0, 0, 2, 255, 255,
+        ];
+        let command = ArtCommand::from_buffer(packet).unwrap();
+        if let ArtCommand::Output(output) = command {
+            assert_eq!(output.version, [0, 0]);
+            assert_eq!(output.sequence, 0);
+            assert_eq!(output.physical, 0);
+            assert_eq!(output.port_address, 1.into());
+            assert_eq!(output.length.parsed_length, Some(2));
+            assert_eq!(output.data.inner, vec![255, 255]);
+        }
+    }
+
+    #[test]
+    fn invalid_port_address() {
+        // Here Port-Address is 32_768
+        // Any Port-Address over 32_767 should fail
+        assert!(ArtCommand::from_buffer(
+            &vec![
+                vec![65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0,],
+                32_768u16.to_le_bytes().to_vec(),
+                vec![0, 2, 255, 255,],
+            ]
+            .concat()
+        )
+        .is_err());
+    }
+}

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -23,12 +23,12 @@ bitflags! {
     }
 }
 
-impl Convertable for ArtTalkToMe {
+impl<T> Convertable<T> for ArtTalkToMe {
     fn from_cursor(cursor: &mut Cursor<&[u8]>) -> Result<Self> {
         let b = cursor.read_u8().map_err(Error::CursorEof)?;
         Ok(ArtTalkToMe::from_bits_truncate(b))
     }
-    fn into_buffer(&self, buffer: &mut Vec<u8>) -> Result<()> {
+    fn into_buffer(&self, buffer: &mut Vec<u8>, _: &T) -> Result<()> {
         buffer.push(self.bits());
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
 
     /// Unknown opcode ID
     UnknownOpcode(u16),
+
+    /// The Art-Net PortAddress was not from 0 to 32_767
+    InvalidPortAddress(i32),
 }
 
 impl std::fmt::Display for Error {
@@ -70,6 +73,11 @@ impl std::fmt::Display for Error {
                 write!(fmt, "Could not parse opcode {:?}: {}", opcode, inner)
             }
             Error::UnknownOpcode(opcode) => write!(fmt, "Unknown opcode 0x{:X}", opcode),
+            Error::InvalidPortAddress(wrong_number) => write!(
+                fmt,
+                "Art-Net PortAddress must be from 0 to 32_767. Got {:?}",
+                wrong_number
+            ),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,15 @@ pub enum Error {
     /// Could not deserialize an artnet command
     DeserializeError(&'static str, Box<Error>),
 
+    /// The given message was too short
+    MessageTooShort {
+        /// The message that was being send or received
+        message: Vec<u8>,
+
+        /// The minimal length that is supported
+        min_len: usize,
+    },
+
     /// The given message was too long or too short
     MessageSizeInvalid {
         /// The message that was being send or received
@@ -40,6 +49,12 @@ impl std::fmt::Display for Error {
             Error::CursorEof(inner) => write!(fmt, "Cursor EOF: {}", inner),
             Error::SerializeError(message, inner) => write!(fmt, "{}: {}", message, inner),
             Error::DeserializeError(message, inner) => write!(fmt, "{}: {}", message, inner),
+            Error::MessageTooShort { message, min_len } => write!(
+                fmt,
+                "Message too short, it was {} but artnet expects at least {}",
+                message.len(),
+                min_len
+            ),
             Error::MessageSizeInvalid {
                 message,
                 allowed_size,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 /// The result that this crate uses
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -13,8 +15,14 @@ pub enum Error {
     /// Could not deserialize an artnet command
     DeserializeError(&'static str, Box<Error>),
 
-    /// The given message was not long enough
-    MessageTooShort(Vec<u8>),
+    /// The given message was too long or too short
+    MessageSizeInvalid {
+        /// The message that was being send or received
+        message: Vec<u8>,
+
+        /// The size that the artnet protocol expects
+        allowed_size: Range<usize>,
+    },
 
     /// The artnet header is invalid
     InvalidArtnetHeader(Vec<u8>),
@@ -32,7 +40,16 @@ impl std::fmt::Display for Error {
             Error::CursorEof(inner) => write!(fmt, "Cursor EOF: {}", inner),
             Error::SerializeError(message, inner) => write!(fmt, "{}: {}", message, inner),
             Error::DeserializeError(message, inner) => write!(fmt, "{}: {}", message, inner),
-            Error::MessageTooShort(_) => write!(fmt, "Message too short"),
+            Error::MessageSizeInvalid {
+                message,
+                allowed_size,
+            } => write!(
+                fmt,
+                "Message size invalid, it was {} but artnet expects between {} and {}",
+                message.len(),
+                allowed_size.start,
+                allowed_size.end
+            ),
             Error::InvalidArtnetHeader(_) => write!(fmt, "Invalid artnet header"),
             Error::OpcodeError(opcode, inner) => {
                 write!(fmt, "Could not parse opcode {:?}: {}", opcode, inner)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ mod command;
 mod convert;
 mod enums;
 mod error;
+mod port_address;
 
 pub use crate::command::*;
 pub use crate::enums::ArtTalkToMe;
 pub use crate::error::*;
+pub use port_address::PortAddress;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,7 @@
 //!         ArtCommand::PollReply(reply) => {
 //!             // This is an ArtNet node on the network. We can send commands to it like this:
 //!             let command = ArtCommand::Output(Output {
-//!                 length: 5, // must match your data.len()
-//!                 data: vec![1, 2, 3, 4, 5], // The data we're sending to the node
+//!                 data: vec![1, 2, 3, 4, 5].into(), // The data we're sending to the node
 //!                 ..Output::default()
 //!             });
 //!             let bytes = command.into_buffer().unwrap();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! data_structure {
 
                 let mut result = Vec::new();
                 $(
-                    self.$field.into_buffer(&mut result)
+                    self.$field.into_buffer(&mut result, &self)
                         .map_err(|e| Error::SerializeError(concat!("Could not serialize field ", stringify!($name), "::", stringify!($field)), Box::new(e)))?;
                 )*
                 Ok(result)
@@ -37,7 +37,7 @@ macro_rules! data_structure {
 
                 let mut cursor = ::std::io::Cursor::new(data);
                 $(
-                    let $field: $ty = Convertable::from_cursor(&mut cursor)
+                    let $field: $ty = Convertable::<$name>::from_cursor(&mut cursor)
                         .map_err(|e| Error::DeserializeError(concat!("Could not deserialize field ", stringify!($name), "::", stringify!($field)), Box::new(e)))?;
                 )*
                 Ok($name {
@@ -51,13 +51,13 @@ macro_rules! data_structure {
         fn test_encode_decode() {
             let start = $name {
                 $(
-                    $field: crate::convert::Convertable::get_test_value(),
+                    $field: crate::convert::Convertable::<$name>::get_test_value(),
                 )*
             };
             let bytes = start.to_bytes().expect("Could not serialize");
             let end = $name::from(&bytes).expect("Could not deserialize");
             $(
-                assert!(crate::convert::Convertable::is_equal(&start.$field, &end.$field));
+                assert!(crate::convert::Convertable::<$name>::is_equal(&start.$field, &end.$field));
             )*
         }
     };

--- a/src/port_address.rs
+++ b/src/port_address.rs
@@ -1,0 +1,106 @@
+use crate::{convert::Convertable, Error, Result};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use std::convert::TryFrom;
+use std::io::Cursor;
+
+/// A `PortAddress` is an unsigned integer from 0 to 32_767 (15-bit).
+///
+/// The trait `From` is implemented for `u8`and `TryFrom` for `u16` and `i32`:
+///
+/// ```
+/// use artnet_protocol::PortAddress;
+/// use std::convert::TryInto;
+/// let a: PortAddress = 1.into(); //convert from u8 never fails
+/// let b: PortAddress = 2u16.try_into().unwrap(); //u16 could fail if too big
+/// let c: PortAddress = 3_000.try_into().unwrap(); //i32 could fail if too big or negative
+/// //PortAddress of 0 is discouraged because sACN does not support a universe 0
+/// let better_not = PortAddress::from(0);
+/// ```
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct PortAddress(u16);
+
+// basic support for u8 literals
+impl From<u8> for PortAddress {
+    fn from(value: u8) -> Self {
+        // cannot over/underflow
+        PortAddress(value as u16)
+    }
+}
+
+impl TryFrom<u16> for PortAddress {
+    type Error = Error;
+    fn try_from(value: u16) -> Result<Self> {
+        if value <= 32_767 {
+            Ok(PortAddress(value))
+        } else {
+            Err(Error::InvalidPortAddress(value.into()))
+        }
+    }
+}
+
+// support un-annotated literals
+impl TryFrom<i32> for PortAddress {
+    type Error = Error;
+    fn try_from(value: i32) -> Result<Self> {
+        if value <= 32_767 && value >= 0 {
+            Ok(PortAddress(value as u16))
+        } else {
+            Err(Error::InvalidPortAddress(value))
+        }
+    }
+}
+
+impl<T> Convertable<T> for PortAddress {
+    fn from_cursor(cursor: &mut Cursor<&[u8]>) -> Result<Self> {
+        let number = cursor
+            .read_u16::<LittleEndian>()
+            .map_err(Error::CursorEof)?;
+        PortAddress::try_from(number)
+    }
+
+    fn into_buffer(&self, buffer: &mut Vec<u8>, _context: &T) -> Result<()> {
+        buffer
+            .write_u16::<LittleEndian>(self.0)
+            .map_err(Error::CursorEof)
+    }
+
+    fn get_test_value() -> Self {
+        PortAddress::from(1)
+    }
+
+    fn is_equal(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn port_address_bound_check() {
+        use std::convert::TryInto;
+        assert!(
+            PortAddress::try_from(32_768u16).is_err(),
+            "u16 values over 32_767 should not convert to PortAddress succesfully"
+        );
+        assert!(
+            PortAddress::try_from(32_768).is_err(),
+            "i32 values over 32_767 should not convert to PortAddress succesfully"
+        );
+        assert!(
+            PortAddress::try_from(-1).is_err(),
+            "negative i32 values should not convert to PortAddress succesfully"
+        );
+        assert!(
+            PortAddress::try_from(-1_000).is_err(),
+            "negative i32 values should not convert to PortAddress succesfully"
+        );
+
+        //should run without panic:
+        let _c: PortAddress = 0.into();
+        let _d: PortAddress = 255.into();
+        let _e: PortAddress = 32_767.try_into().unwrap();
+        let _f: PortAddress = 256.try_into().unwrap();
+        let _f: PortAddress = 32_767u16.try_into().unwrap();
+    }
+}


### PR DESCRIPTION
This PR closes #6 and #7

Output.data now uses interior mutability, because it needs to add an additional byte if the given data is an uneven length. In addition, Output.data now throws an error when trying to serialize an empty value, or a value that is larger than 512 bytes.

Output.length is now a helper struct that is set when serialized, and cannot be set by the developer directly.

Output.length is now also written in BigEndian format

cc @Firionus
