### PR TITLE
Make data in PaddedData accesible

### DIFF
--- a/src/command/output/mod.rs
+++ b/src/command/output/mod.rs
@@ -55,15 +55,20 @@ pub struct PaddedData {
 }
 
 impl PaddedData {
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.inner.len()
     }
+
     fn len_rounded_up(&self) -> usize {
         let mut len = self.inner.len();
         if len % 2 != 0 {
             len += 1;
         }
         len
+    }
+
+    pub fn get(&self) -> &[u8] {
+        &self.inner
     }
 }
 


### PR DESCRIPTION
I needed access to the data in the output, so added an accessor.