### PR TITLE
Make PaddedData public

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -5,7 +5,7 @@ mod poll_reply;
 use crate::{Error, Result};
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 
-pub use self::output::Output;
+pub use self::output::{Output, PaddedData};
 pub use self::poll::Poll;
 pub use self::poll_reply::PollReply;
 

--- a/src/command/output/mod.rs
+++ b/src/command/output/mod.rs
@@ -50,6 +50,7 @@ impl Default for Output {
 }
 
 #[derive(Default)]
+#[doc = "Data in an ArtDmx data packet."]
 pub struct PaddedData {
     inner: Vec<u8>,
 }


### PR DESCRIPTION
I wanted to create some PaddedData structs for use in unit tests, but couldn't since it was not pub used.