### PR TITLE
Fix FrameType export

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -9,7 +9,7 @@ use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 pub use self::output::{Output, PaddedData};
 pub use self::poll::Poll;
 pub use self::poll_reply::PollReply;
-pub use self::timecode::Timecode;
+pub use self::timecode::{FrameType, Timecode};
 
 /// The ArtCommand, to be used for ArtNet.
 ///

--- a/src/command/timecode.rs
+++ b/src/command/timecode.rs
@@ -34,6 +34,7 @@ data_structure! {
     }
 }
 
+/// The framerate being used for a particular [Timecode] stream.
 #[repr(u8)]
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum FrameType {


### PR DESCRIPTION
This PR exports the `FrameType` enum just like `Timecode` and adds a doc string to satisfy the missing docs lint in `lib.rs`.

Without the re-export, users of `artnet_protocol` aren't able to use matches to run conditional logic based on frame rate and can't form their own packets to send timecode.