### PR TITLE
Add derives for basic traits to data structs

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -15,7 +15,7 @@ pub use self::timecode::{FrameType, Timecode};
 ///
 /// This struct implements an `write_to_buffer` and `from_buffer` function, to be used with UDP connections.
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum ArtCommand {
     /// A poll command, used to discover devices on the network
     Poll(Poll),

--- a/src/command/output/mod.rs
+++ b/src/command/output/mod.rs
@@ -6,7 +6,7 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::Cursor;
 
 data_structure! {
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
     #[doc = "ArtDmx is the data packet used to transfer DMX512 data. The format is identical for Node to Controller, Node to Node and Controller to Node."]
     #[doc = ""]
     #[doc = "The Data is output through the DMX O/P port corresponding to the Universe setting. In the absence of received ArtDmx packets, each DMX O/P port re-transmits the same frame continuously. "]
@@ -49,7 +49,7 @@ impl Default for Output {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 #[doc = "Data in an ArtDmx data packet."]
 pub struct PaddedData {
     inner: Vec<u8>,
@@ -137,7 +137,7 @@ impl<T> Convertable<T> for PaddedData {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct BigEndianLength<T> {
     parsed_length: Option<u16>,
     _pd: std::marker::PhantomData<T>,

--- a/src/command/poll.rs
+++ b/src/command/poll.rs
@@ -1,7 +1,7 @@
 use crate::ArtTalkToMe;
 
 data_structure! {
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
     #[doc = "Used to poll the nodes in the network"]
     pub struct Poll {
         #[doc = "Determines which version the server has. Will be ARTNET_PROTOCOL_VERSION by default"]

--- a/src/command/poll_reply.rs
+++ b/src/command/poll_reply.rs
@@ -5,6 +5,7 @@ use std::str;
 use crate::ARTNET_PROTOCOL_VERSION;
 
 data_structure! {
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
     #[doc = "Gets send by the nodes in the network as a response to the Poll message"]
     pub struct PollReply {
         #[doc = "The IP address of the node"]

--- a/src/command/timecode.rs
+++ b/src/command/timecode.rs
@@ -5,7 +5,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use crate::{convert::Convertable, Error, Result, ARTNET_PROTOCOL_VERSION};
 
 data_structure! {
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
     #[doc = "Used to for timecode on the network"]
     pub struct Timecode {
         #[doc = "Determines which version the server has. Will be ARTNET_PROTOCOL_VERSION by default"]
@@ -45,7 +45,7 @@ impl Default for Timecode {
 
 /// The framerate being used for a particular [Timecode] stream.
 #[repr(u8)]
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub enum FrameType {
     #[doc = "FrameType Film 24fps"]
     Film = 0,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -4,7 +4,7 @@ use crate::{Error, Result};
 use std::io::Cursor;
 
 bitflags! {
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
     /// The TalkToMe flag, as to be used in the `Poll` and `PollReply` message
     pub struct ArtTalkToMe: u8 {
         /// Enable VLC transmission if set, disabled otherwise


### PR DESCRIPTION
This is a pretty minor PR, which adds derives for common rust traits to all publicly accesible data structs (and two enums aswell)

The derive marco was added to the structs directly, instead of the data_structure macro, since some derives, like Debug or Default, have a explicit implementation on some structs already.

resolves #47